### PR TITLE
Added - `clear` command

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -829,6 +829,30 @@ registerPlugin({
                     }));
                 }
             },
+            'clear': {
+                syntax: false,
+                active: true,
+                hidden: false,
+                admin: false,
+                callback: function (data) {
+                    var media = require('media');
+
+                    let message = '';
+                    if (media.clearQueue() && media.stop()) {
+                        media.clearIdleTrack();
+
+                        message = 'Queue has been cleared!';
+                        engine.log('Queue cleared!');
+                    } else {
+                        message = 'Could not clear the queue, please do so manually.';
+                        engine.log('Queue failed to clear');
+                    }
+
+                    youtube.msg(Object.assign(data, {
+                        text: message
+                    }));
+                }
+            },
             'resetkey': {
                 syntax: 'Syntax !{cmd}-{par}',
                 active: true,


### PR DESCRIPTION
What
=================
The `clear` command allows a user to clear the current queue, stop the
currently playing song and remove that too. Essentially it allows them
to start a clean slate and add other songs on instead.
I have no idea why this wasn't ever a function in the first place...

Issue ID: N/A